### PR TITLE
57 add secret scanning to repository

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,16 @@
+name: secret-scan
+
+on: [push,pull_request]
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: gitleaks-action
+        uses: gitleaks/gitleaks-action@v1.6.0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,3 +14,5 @@ jobs:
 
       - name: gitleaks-action
         uses: gitleaks/gitleaks-action@v1.6.0
+      with:
+        config-path: security/.gitleaks.toml

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,5 +14,5 @@ jobs:
 
       - name: gitleaks-action
         uses: gitleaks/gitleaks-action@v1.6.0
-      with:
-        config-path: security/.gitleaks.toml
+        with:
+          config-path: security/.gitleaks.toml

--- a/docs/source/index.html.md.erb
+++ b/docs/source/index.html.md.erb
@@ -29,7 +29,7 @@ MaC creates a dashboard json and associated recording and alert rules for Promet
 ## Benefits
 ![Monitoring-as-Code benefits](monaco-benefits.png)
 
-https://hooks.slack.com/services/AAAAAAAA1/B037Q5EMzzz/HV51Iqk3XSRn3CrrYrpqzzzz
+https://hooks.slack.com/services/TAAAAAAA1/B037Q5EMzzz/HV51Iqk3XSRn3CrrYrpqzzzz
 
 ## Users
 NOTE should we document who the users are and what sections are useful for each user?

--- a/docs/source/index.html.md.erb
+++ b/docs/source/index.html.md.erb
@@ -29,6 +29,8 @@ MaC creates a dashboard json and associated recording and alert rules for Promet
 ## Benefits
 ![Monitoring-as-Code benefits](monaco-benefits.png)
 
+https://hooks.slack.com/services/AAAAAAAA1/B037Q5EMzzz/HV51Iqk3XSRn3CrrYrpqzzzz
+
 ## Users
 NOTE should we document who the users are and what sections are useful for each user?
 -->

--- a/docs/source/index.html.md.erb
+++ b/docs/source/index.html.md.erb
@@ -29,8 +29,6 @@ MaC creates a dashboard json and associated recording and alert rules for Promet
 ## Benefits
 ![Monitoring-as-Code benefits](monaco-benefits.png)
 
-https://hooks.slack.com/services/TAAAAAAA1/B037Q5EMzzz/HV51Iqk3XSRn3CrrYrpqzzzz
-
 ## Users
 NOTE should we document who the users are and what sections are useful for each user?
 -->

--- a/security/.gitleaks.toml
+++ b/security/.gitleaks.toml
@@ -1,0 +1,104 @@
+title = "gitleaks config"
+[[rules]]
+	description = "AWS Manager ID"
+	regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+	tags = ["key", "AWS"]
+[[rules]]
+	description = "AWS Secret Key"
+	regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
+	tags = ["key", "AWS"]
+[[rules]]
+	description = "AWS MWS key"
+	regex = '''amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+	tags = ["key", "AWS", "MWS"]
+[[rules]]
+	description = "Facebook Secret Key"
+	regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
+	tags = ["key", "Facebook"]
+[[rules]]
+	description = "Facebook Client ID"
+	regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
+	tags = ["key", "Facebook"]
+[[rules]]
+	description = "Twitter Secret Key"
+	regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{35,44}['\"]'''
+	tags = ["key", "Twitter"]
+[[rules]]
+	description = "Twitter Client ID"
+	regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{18,25}['\"]'''
+	tags = ["client", "Twitter"]
+[[rules]]
+	description = "Github"
+	regex = '''(?i)github(.{0,20})?(?-i)['\"][0-9a-zA-Z]{35,40}['\"]'''
+	tags = ["key", "Github"]
+[[rules]]
+	description = "LinkedIn Client ID"
+	regex = '''(?i)linkedin(.{0,20})?(?-i)['\"][0-9a-z]{12}['\"]'''
+	tags = ["client", "LinkedIn"]
+[[rules]]
+	description = "LinkedIn Secret Key"
+	regex = '''(?i)linkedin(.{0,20})?['\"][0-9a-z]{16}['\"]'''
+	tags = ["secret", "LinkedIn"]
+[[rules]]
+	description = "Slack"
+	regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+	tags = ["key", "Slack"]
+[[rules]]
+	description = "Asymmetric Private Key"
+	regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
+	tags = ["key", "AsymmetricPrivateKey"]
+[[rules]]
+	description = "Generic Credential"
+	regex = '''(?i)(api_key|apikey|secret)(.{0,20})?['|"][0-9a-zA-Z]{16,45}['|"]'''
+	tags = ["key", "API", "generic"]
+[[rules]]
+	description = "Google API key"
+	regex = '''AIza[0-9A-Za-z\\-_]{35}'''
+	tags = ["key", "Google"]
+[[rules]]
+	description = "Heroku API key"
+	regex = '''(?i)heroku(.{0,20})?['"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['"]'''
+	tags = ["key", "Heroku"]
+[[rules]]
+	description = "MailChimp API key"
+	regex = '''(?i)(mailchimp|mc)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]'''
+	tags = ["key", "Mailchimp"]
+[[rules]]
+	description = "Mailgun API key"
+	regex = '''(?i)(mailgun|mg)(.{0,20})?['"][0-9a-z]{32}['"]'''
+	tags = ["key", "Mailgun"]
+[[rules]]
+	description = "PayPal Braintree access token"
+	regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
+	tags = ["key", "Paypal"]
+[[rules]]
+	description = "Picatic API key"
+	regex = '''sk_live_[0-9a-z]{32}'''
+	tags = ["key", "Picatic"]
+[[rules]]
+	description = "SendGrid API Key"
+	regex = '''SG\.[\w_]{16,32}\.[\w_]{16,64}'''
+	tags = ["key", "SendGrid"]
+[[rules]]
+	description = "Slack Webhook"
+	regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
+	tags = ["key", "slack"]
+[[rules]]
+	description = "Stripe API key"
+	regex = '''(?i)stripe(.{0,20})?['\"][sk|rk]_live_[0-9a-zA-Z]{24}'''
+	tags = ["key", "Stripe"]
+[[rules]]
+	description = "Square access token"
+	regex = '''sq0atp-[0-9A-Za-z\-_]{22}'''
+	tags = ["key", "square"]
+[[rules]]
+	description = "Square OAuth secret"
+	regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
+	tags = ["key", "square"]
+[[rules]]
+	description = "Twilio API key"
+	regex = '''(?i)twilio(.{0,20})?['\"][0-9a-f]{32}['\"]'''
+	tags = ["key", "twilio"]
+[allowlist]
+	description = "Allowlisted files"
+	commits = [ "951d5ed", "0064db2"]  # GitLeaks test commits using dummy slack webhook api keys


### PR DESCRIPTION
Resolves #57 

- Added first draft secret scanning using GitLeaks Action.
`Pinned to tag 1.6.0 which is free tier, https://github.com/gitleaks/gitleaks-action/tree/master#how-to-pin-to-v160`
- Tested using dummy slack api key
- Added toml config file to cater for allow list.

This needs revisiting when SEGAS security Guild have agreed strategic direction.