### PR TITLE
115 dependabot refinement ignore packages like gitleaks action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "gitleaks"
-        # For gitleaks, ignore all updates as new version then 1.6.0 are paid for
+      - dependency-name: "gitleaks/gitleaks-action"
+        # For gitleaks/gitleaks-action, ignore all updates as new version then 1.6.0 are paid for
       
   - package-ecosystem: "docker"
     directory: "/docs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "gitleaks"
+        # For gitleaks, ignore all updates as new version then 1.6.0 are paid for
       
   - package-ecosystem: "docker"
     directory: "/docs"
@@ -26,7 +29,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/monitoring-as-code"
     schedule:
-      interval: "weekly"     
+      interval: "weekly"
 
   - package-ecosystem: "bundler"
     directory: "/monitoring-as-code"


### PR DESCRIPTION
syntax should remove gitleaks/gitleaks-action from being checked by dependabot