### PR TITLE
Update gemfile with haml ver 5.x

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -8,5 +8,8 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw, :x64_mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :x64_mingw, :jruby]
 
+# Haml file is limited to 5.x as 6.0 has problem with middleman
+gem "haml", "~> 5.0" 
+
 # Include the tech docs gem
 gem 'govuk_tech_docs'


### PR DESCRIPTION
Haml was updated to 6.0 on 21st Sept. This seems to have caused a problem with middleman. By limiting the haml ver to 5.x should avoid the problem.