### PR TITLE
Remove references to queue_type.

### DIFF
--- a/monitoring-as-code/src/dashboards/detail-dashboard-elements/cloudwatch-sqs.libsonnet
+++ b/monitoring-as-code/src/dashboards/detail-dashboard-elements/cloudwatch-sqs.libsonnet
@@ -5,9 +5,7 @@
 // oldestMessage - Metric representing the age of oldest message
 
 // Additional config:
-// deadletterQueueType custom selector label in metric type config
 // deadletterQueueName custom selector label in metric type config
-// deadletterQueueType custom selector in metric type config
 // deadletterQueueName custom selector in metric type config
 
 // MaC imports
@@ -91,12 +89,12 @@ local createCustomSelectors(direction, customSelectorLabels, customSelectorValue
       customSelectorLabels.deadletterQueueName
     )),
     standardQueue: std.join(', ', std.map(
-      function(selectorLabel) '%s!~"%s|"' % [selectorLabel, std.join('|', customSelectorValues.deadletterQueueType)],
-      customSelectorLabels.deadletterQueueType
+      function(selectorLabel) '%s!~"%s|"' % [selectorLabel, std.join('|', customSelectorValues.deadletterQueueName)],
+      customSelectorLabels.deadletterQueueName
     )),
     deadletterQueue: std.join(', ', std.map(
-      function(selectorLabel) '%s=~"%s|"' % [selectorLabel, std.join('|', customSelectorValues.deadletterQueueType)],
-      customSelectorLabels.deadletterQueueType
+      function(selectorLabel) '%s=~"%s|"' % [selectorLabel, std.join('|', customSelectorValues.deadletterQueueName)],
+      customSelectorLabels.deadletterQueueName
     )),
   };
 

--- a/monitoring-as-code/src/metric-types.libsonnet
+++ b/monitoring-as-code/src/metric-types.libsonnet
@@ -269,11 +269,9 @@
       },
       customSelectorLabels: {
         deadletterQueueName: 'dimension_QueueName',
-        deadletterQueueType: 'dimension_queue_type',
       },
       customSelectors: {
         deadletterQueueName: '.+dlq.+',
-        deadletterQueueType: 'deadletter',
       },
     },
     sliTypesConfig: {


### PR DESCRIPTION
Fixes #354 

Filtering should still happen on QueueName, so SQS queues matching `.+dlq.+` will be considered dead-letter queues, whilst queues not matching this pattern will be considered standard queues.