### PR TITLE
Add health indicator status metric to Java app.

### DIFF
--- a/example-apps/sre-demo-java-app/src/main/java/hocto/sredemojavaapp/HealthMetricsExportConfiguration.java
+++ b/example-apps/sre-demo-java-app/src/main/java/hocto/sredemojavaapp/HealthMetricsExportConfiguration.java
@@ -1,0 +1,31 @@
+package hocto.sredemojavaapp;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration(proxyBeanMethods = false)
+public class HealthMetricsExportConfiguration {
+
+    public HealthMetricsExportConfiguration(MeterRegistry registry, HealthEndpoint healthEndpoint) {
+        Gauge.builder("health", healthEndpoint, this::getStatusCode).strongReference(true).register(registry);
+    }
+
+    private int getStatusCode(HealthEndpoint health) {
+        Status status = health.health().getStatus();
+        if (Status.UP.equals(status)) {
+            return 3;
+        }
+        if (Status.OUT_OF_SERVICE.equals(status)) {
+            return 2;
+        }
+        if (Status.DOWN.equals(status)) {
+            return 1;
+        }
+        return 0;
+    }
+
+}


### PR DESCRIPTION
Fixes #367 

Before this change, there was no `health` metric exposed at the `/actuator/prometheus` endpoint.
After this change there is now a `health` metric exposed which shows the "up" health indicator status of the spring boot application.