### PR TITLE
Add platforms to gem file

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -127,6 +127,10 @@ GEM
     multi_json (1.15.0)
     nokogiri (1.13.9-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
     padrino-helpers (0.15.1)
@@ -167,6 +171,8 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   govuk_tech_docs


### PR DESCRIPTION
## Purpose of pull request
_Describe the problem or feature in addition to a link to the issues when possible._
Due to adding the gemlock file to repo there have been platform issues. Primarily the fact the branch was work on a m2 mac. However now the correct linux amd64 platform was added.

Fixes #418 

## How to test
_Describe the how you would test this change._
Not applicable 