### PR TITLE
fix: Generate correct value for SLI even if there are no metrics available (div/0)

### DIFF
--- a/monitoring-as-code/src/sli-value-libraries/availability-gauge-using-1-failure-metric-for-num-and-1-total-metric-for-dem.libsonnet
+++ b/monitoring-as-code/src/sli-value-libraries/availability-gauge-using-1-failure-metric-for-num-and-1-total-metric-for-dem.libsonnet
@@ -34,7 +34,7 @@ local createSliValueRule(sliSpec, sliMetadata, config) =
               sum by(%(selectorLabels)s) (avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
               /
               sum by(%(selectorLabels)s) (avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
-            ) > 0 or on() vector(100)
+            ) > 0 or on() vector(0)
           ),
         "sli_environment", "$1", "%(environmentSelectorLabel)s", "(.*)"), "sli_product", "$1", "%(productSelectorLabel)s", "(.*)"))
       ||| % {
@@ -100,7 +100,7 @@ local createGraphPanel(sliSpec) =
         sum(avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s]) >=0 or vector(0))
         /
         sum(avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s]) >=0 or vector(0))
-        ) > 0 or on() vector(100)
+        ) > 0 or on() vector(0)
       ||| % {
         failureMetric: targetMetrics.failure,
         totalMetric: targetMetrics.total,

--- a/monitoring-as-code/src/sli-value-libraries/availability-gauge-using-1-failure-metric-for-num-and-1-total-metric-for-dem.libsonnet
+++ b/monitoring-as-code/src/sli-value-libraries/availability-gauge-using-1-failure-metric-for-num-and-1-total-metric-for-dem.libsonnet
@@ -30,9 +30,11 @@ local createSliValueRule(sliSpec, sliMetadata, config) =
       expr: |||
         sum without (%(selectorLabels)s) (label_replace(label_replace(
           (
-            sum by(%(selectorLabels)s) (avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
-            /
-            sum by(%(selectorLabels)s) (avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
+            (
+              sum by(%(selectorLabels)s) (avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
+              /
+              sum by(%(selectorLabels)s) (avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
+            ) > 0 or on() vector(100)
           ),
         "sli_environment", "$1", "%(environmentSelectorLabel)s", "(.*)"), "sli_product", "$1", "%(productSelectorLabel)s", "(.*)"))
       ||| % {
@@ -94,9 +96,11 @@ local createGraphPanel(sliSpec) =
   ).addTarget(
     prometheus.target(
       |||
+        (
         sum(avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s]) >=0 or vector(0))
         /
         sum(avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s]) >=0 or vector(0))
+        ) > 0 or on() vector(100)
       ||| % {
         failureMetric: targetMetrics.failure,
         totalMetric: targetMetrics.total,


### PR DESCRIPTION
## Purpose of pull request
Some SLIs fail to generate a valid metric when there is no data. This PR protects from that behaviour by defaulting to no failures if the data is not available.
