### PR TITLE
fix: revert broken changes to value library

### DIFF
--- a/monitoring-as-code/src/sli-value-libraries/availability-gauge-using-1-failure-metric-for-num-and-1-total-metric-for-dem.libsonnet
+++ b/monitoring-as-code/src/sli-value-libraries/availability-gauge-using-1-failure-metric-for-num-and-1-total-metric-for-dem.libsonnet
@@ -30,11 +30,9 @@ local createSliValueRule(sliSpec, sliMetadata, config) =
       expr: |||
         sum without (%(selectorLabels)s) (label_replace(label_replace(
           (
-            (
-              sum by(%(selectorLabels)s) (avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
-              /
-              sum by(%(selectorLabels)s) (avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
-            ) > 0 or on() vector(0)
+            sum by(%(selectorLabels)s) (avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
+            /
+            sum by(%(selectorLabels)s) (avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s])>=0)
           ),
         "sli_environment", "$1", "%(environmentSelectorLabel)s", "(.*)"), "sli_product", "$1", "%(productSelectorLabel)s", "(.*)"))
       ||| % {
@@ -96,11 +94,9 @@ local createGraphPanel(sliSpec) =
   ).addTarget(
     prometheus.target(
       |||
-        (
         sum(avg_over_time(%(failureMetric)s{%(selectors)s}[%(evalInterval)s]) >=0 or vector(0))
         /
         sum(avg_over_time(%(totalMetric)s{%(selectors)s}[%(evalInterval)s]) >=0 or vector(0))
-        ) > 0 or on() vector(0)
       ||| % {
         failureMetric: targetMetrics.failure,
         totalMetric: targetMetrics.total,


### PR DESCRIPTION
## Purpose of pull request
Reverting recent changes as if you have a metric value as 0 for failure metric it strips labels and breaks the charts
